### PR TITLE
Fix canvas coordinate mapping in portrait mode and prevent brush size button shrinking

### DIFF
--- a/src/pages/FieldDrawPage.jsx
+++ b/src/pages/FieldDrawPage.jsx
@@ -112,6 +112,20 @@ export function FieldDrawPage() {
   const getPos = (e, canvas) => {
     const rect = canvas.getBoundingClientRect();
     const src = e.touches ? e.touches[0] : e;
+
+    // In portrait mode the whole page is CSS-rotated 90° CW, so
+    // getBoundingClientRect() returns visual (post-rotation) bounds where
+    // width ≈ canvas logical height and height ≈ canvas logical width.
+    // We must swap and invert the axes to get correct canvas coordinates.
+    if (window.matchMedia('(orientation: portrait)').matches) {
+      const vx = src.clientX - rect.left;
+      const vy = src.clientY - rect.top;
+      return {
+        x: (rect.height - vy) * (canvas.width / rect.height),
+        y: vx * (canvas.height / rect.width),
+      };
+    }
+
     return {
       x: (src.clientX - rect.left) * (canvas.width / rect.width),
       y: (src.clientY - rect.top) * (canvas.height / rect.height),
@@ -246,7 +260,7 @@ export function FieldDrawPage() {
                 className={`field-size-btn ${size === s ? 'active' : ''}`}
                 onClick={() => setSize(s)}
               >
-                <span style={{ width: Math.min(s * 1.8, 22), height: Math.min(s * 1.8, 22), borderRadius: '50%', background: '#fff', display: 'block' }} />
+                <span style={{ width: Math.min(s * 1.8, 22), height: Math.min(s * 1.8, 22), borderRadius: '50%', background: '#fff', display: 'block', flexShrink: 0 }} />
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Summary
This PR fixes two issues in the FieldDrawPage component: incorrect canvas coordinate calculations in portrait mode and unintended shrinking of brush size selector buttons.

## Key Changes
- **Portrait mode coordinate mapping**: Added special handling for portrait orientation where the page is CSS-rotated 90° clockwise. The fix swaps and inverts axes to correctly map touch/mouse coordinates to canvas coordinates, accounting for the visual bounds returned by `getBoundingClientRect()` after rotation.
- **Brush size button layout**: Added `flexShrink: 0` to the brush size preview circle to prevent it from shrinking when space is constrained, ensuring consistent button appearance.

## Implementation Details
The portrait mode fix detects orientation using `window.matchMedia('(orientation: portrait)')` and applies coordinate transformation:
- Swaps x/y axes due to 90° rotation
- Inverts the y-axis to account for the clockwise rotation direction
- Scales coordinates using the swapped canvas dimensions relative to the visual bounds

This ensures drawing input is accurately mapped to the canvas regardless of device orientation.

https://claude.ai/code/session_017BWDRb8Tfjo1Qc3tvZtp4e